### PR TITLE
Fix filter for numerical options

### DIFF
--- a/examples/src/components/AllowCreate.js
+++ b/examples/src/components/AllowCreate.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Select from 'react-select';
 
 const FLAVOURS = [
-	{ label: 'Chocolate', value: 'chocolate' },
+	{ label: 'Chocolate', value: 42 },
 	{ label: 'Vanilla', value: 'vanilla' },
 	{ label: 'Strawberry', value: 'strawberry' },
 	{ label: 'Caramel', value: 'caramel' },

--- a/src/Select.js
+++ b/src/Select.js
@@ -867,7 +867,7 @@ const Select = React.createClass({
 			let addNewOption = true;
 			//NOTE: only add the "Add" option if none of the options are an exact match
 			filteredOptions.map(option => {
-				if (option.label.toLowerCase() === filterValue || option.value.toLowerCase() === filterValue) {
+				if (String(option.label).toLowerCase() === filterValue || String(option.value).toLowerCase() === filterValue) {
 					addNewOption = false;
 				}
 			});


### PR DESCRIPTION
Prevent a filtering error when allowCreate is true and an option has a numeric
label or value.

To see the error, revert my change to `Select.js`, and enter 4 or 2 into the select in the example.
